### PR TITLE
Updated CI versions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10]
+        python-version: [3.10.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,8 +1,6 @@
 name: Django CI
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.10]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.10.12]
     name: Lint
     steps:
       - name: Check out source repository


### PR DESCRIPTION
Changed C for linter and django to run on python 3.10.12, latest stable version

Instead of 3.8 and 9

Fails linter because of some syntax from main, actual changes work fine